### PR TITLE
ssifbridge: clean up codes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,7 +21,6 @@ AUTOCONF_FILES="Makefile.in aclocal.m4 ar-lib autom4te.cache compile \
 case $1 in
     clean)
         test -f Makefile && make maintainer-clean
-        test -f linux/ssif-bmc.h && rm -rf linux/ssif-bmc.h
         test -d linux && find linux -type d -empty | xargs -r rm -rf
         for file in ${AUTOCONF_FILES}; do
             find -name "$file" | xargs -r rm -rf

--- a/configure.ac
+++ b/configure.ac
@@ -16,10 +16,6 @@ PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 221])
 
 # Checks for header files.
 AC_CHECK_HEADER(systemd/sd-bus.h, ,[AC_MSG_ERROR([Could not find systemd/sd-bus.h...systemd developement package required])])
-AC_CHECK_HEADER(linux/ssif-bmc.h,[HAVE_LINUX_SSIF_BMC_H=""],[HAVE_LINUX_SSIF_BMC_H="-I linux/ssif-bmc.h"])
-AS_IF([test "$HAVE_LINUX_SSIF_BMC_H" != ""],
-    AC_MSG_WARN([Could not find linux/ssif-bmc.h])
-)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AX_APPEND_COMPILE_FLAGS([-fpic -Wall -Werror], [CFLAGS])

--- a/org.openbmc.HostIpmi.conf
+++ b/org.openbmc.HostIpmi.conf
@@ -4,7 +4,7 @@
         "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 
 <!--
-	This file is need to run openbmc ssif bridge daemon.
+	This file is needed to run openbmc ssif bridge daemon.
 	Place this file in /etc/dbus-1/system.d/
 -->
 


### PR DESCRIPTION
Clean up the code to not depend on bmc-ssif.h and make it better in
handling errors.

Signed-off-by: Thang Q. Nguyen <thang@os.amperecomputing.com>